### PR TITLE
Potential fix for code scanning alert no. 6: Full server-side request forgery

### DIFF
--- a/tabs/install.py
+++ b/tabs/install.py
@@ -14,6 +14,8 @@ from rvc.modules.model_manager import (
 embedders_dir = os.path.join(os.getcwd(), "rvc", "models", "embedders")
 hubert_base_path = os.path.join(embedders_dir, "hubert_base.pt")
 
+authorized_domains = ["huggingface.co"]
+
 base_url = "https://huggingface.co/Politrees/RVC_resources/resolve/main/embedders/"
 
 models = [
@@ -49,8 +51,10 @@ def download_and_replace_model(model_name, custom_url, progress=gr.Progress()):
         if custom_url:
             if not custom_url.endswith((".pt", "?download=true")):
                 return "Ошибка: указанный URL не соответствует требованиям. Он должен вести к файлу с расширением .pt или заканчиваться на '?download=true'"
-            model_url = custom_url
             parsed_url = urllib.parse.urlparse(custom_url)
+            if parsed_url.netloc not in authorized_domains:
+                return "Ошибка: указанный URL не принадлежит к разрешенным доменам."
+            model_url = custom_url
             model_name = os.path.basename(parsed_url.path)
         else:
             model_url = base_url + model_name


### PR DESCRIPTION
Potential fix for [https://github.com/Bebra777228/PolGen-RVC/security/code-scanning/6](https://github.com/Bebra777228/PolGen-RVC/security/code-scanning/6)

To fix the problem, we need to ensure that the `custom_url` provided by the user is validated against a list of authorized domains. This can be done by extracting the domain from the URL and checking it against a predefined list of allowed domains. If the domain is not in the list, the request should be rejected.

1. Define a list of authorized domains.
2. Extract the domain from the `custom_url`.
3. Check if the extracted domain is in the list of authorized domains.
4. If the domain is not authorized, return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
